### PR TITLE
Add ToolsApp with focus timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# ios-playground
+# iOS Playground
+
+This repository contains experiments and small projects for learning Swift and iOS development.
+
+## ToolsApp
+
+The `ToolsApp` directory provides a SwiftUI application prepared for multiple tools. The first tool implemented is a focus timer that alternates between focus and relax intervals.
+
+Open `ToolsApp` in Xcode to build and run on your iPhone.

--- a/ToolsApp/README.md
+++ b/ToolsApp/README.md
@@ -1,0 +1,4 @@
+# ToolsApp
+
+A simple SwiftUI application containing a collection of personal tools.
+The first tool is a focus timer with alternating focus and relax intervals.

--- a/ToolsApp/TimerTool/TimerToolView.swift
+++ b/ToolsApp/TimerTool/TimerToolView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct TimerToolView: View {
+    @StateObject private var viewModel = TimerViewModel()
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Text(viewModel.currentPhaseTitle)
+                    .font(.title)
+                    .padding(.top)
+                Text(viewModel.timeString)
+                    .font(.system(size: 64, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("Focus (min)")
+                        Stepper(value: $viewModel.focusMinutes, in: 1...120, step: 1) {
+                            Text("\(Int(viewModel.focusMinutes))")
+                        }
+                    }
+                    VStack(alignment: .leading) {
+                        Text("Relax (min)")
+                        Stepper(value: $viewModel.relaxMinutes, in: 1...120, step: 1) {
+                            Text("\(Int(viewModel.relaxMinutes))")
+                        }
+                    }
+                }
+                Picker("Sound", selection: $viewModel.selectedSound) {
+                    ForEach(TimerSound.allCases) { sound in
+                        Text(sound.rawValue).tag(sound)
+                    }
+                }
+                Toggle("Vibration", isOn: $viewModel.vibrationEnabled)
+                HStack {
+                    Button(action: viewModel.toggleRunning) {
+                        Text(viewModel.isRunning ? "Pause" : "Start")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    Button("Reset") {
+                        viewModel.reset()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .buttonStyle(.bordered)
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Focus Timer")
+        }
+    }
+}
+
+struct TimerToolView_Previews: PreviewProvider {
+    static var previews: some View {
+        TimerToolView()
+    }
+}

--- a/ToolsApp/TimerTool/TimerViewModel.swift
+++ b/ToolsApp/TimerTool/TimerViewModel.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import AVFoundation
+import AudioToolbox
+
+class TimerViewModel: ObservableObject {
+    @Published var focusMinutes: Double = 25 {
+        didSet { if !isRunning { timeRemaining = focusMinutes * 60 } }
+    }
+    @Published var relaxMinutes: Double = 5
+    @Published private(set) var isFocusPhase: Bool = true
+    @Published private(set) var timeRemaining: TimeInterval = 25 * 60
+    @Published private(set) var isRunning: Bool = false
+    @Published var selectedSound: TimerSound = .gentleChime
+    @Published var vibrationEnabled: Bool = false
+
+    private var timer: Timer?
+
+    var timeString: String {
+        let minutes = Int(timeRemaining) / 60
+        let seconds = Int(timeRemaining) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var currentPhaseTitle: String {
+        isFocusPhase ? "Focus" : "Relax"
+    }
+
+    func toggleRunning() {
+        if isRunning {
+            pause()
+        } else {
+            start()
+        }
+    }
+
+    func start() {
+        if timeRemaining <= 0 {
+            resetTime()
+        }
+        isRunning = true
+        scheduleTimer()
+    }
+
+    func pause() {
+        timer?.invalidate()
+        isRunning = false
+    }
+
+    func reset() {
+        timer?.invalidate()
+        isRunning = false
+        isFocusPhase = true
+        timeRemaining = focusMinutes * 60
+    }
+
+    private func scheduleTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func tick() {
+        guard timeRemaining > 0 else {
+            notifyEndOfInterval()
+            isFocusPhase.toggle()
+            resetTime()
+            return
+        }
+        timeRemaining -= 1
+    }
+
+    private func resetTime() {
+        timeRemaining = (isFocusPhase ? focusMinutes : relaxMinutes) * 60
+    }
+
+    private func notifyEndOfInterval() {
+        playSound()
+        if vibrationEnabled {
+            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+        }
+    }
+
+    private func playSound() {
+        guard let url = selectedSound.url else { return }
+        var soundId: SystemSoundID = 0
+        AudioServicesCreateSystemSoundID(url as CFURL, &soundId)
+        AudioServicesPlaySystemSound(soundId)
+    }
+}
+
+enum TimerSound: String, CaseIterable, Identifiable {
+    case gentleChime = "Gentle Chime"
+    case softBell = "Soft Bell"
+    case mellowBeat = "Mellow Beat"
+
+    var id: String { rawValue }
+
+    var fileName: String {
+        switch self {
+        case .gentleChime: return "chime"
+        case .softBell: return "bell"
+        case .mellowBeat: return "beat"
+        }
+    }
+
+    var url: URL? {
+        Bundle.main.url(forResource: fileName, withExtension: "mp3")
+    }
+}

--- a/ToolsApp/ToolsAppApp.swift
+++ b/ToolsApp/ToolsAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ToolsAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MainView()
+        }
+    }
+}

--- a/ToolsApp/Views/MainView.swift
+++ b/ToolsApp/Views/MainView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        TabView {
+            TimerToolView()
+                .tabItem {
+                    Image(systemName: "timer")
+                    Text("Timer")
+                }
+            // Additional tools can be placed here
+        }
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}


### PR DESCRIPTION
## Summary
- add ToolsApp with a SwiftUI scaffold ready for multiple tools
- implement TimerTool as first tool with focus and relax intervals
- customize basic look and allow choosing a gentle sound effect or vibration
- update repository README

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686d3433985c8320b85813df552165c2